### PR TITLE
Ensure service file is executable

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -82,6 +82,7 @@
   template:
     src: service-template.service.j2
     dest: /etc/systemd/system/{{ service_name }}.service
+    mode: "u=rwx,g=r,o=r"
   vars:
     bin: "{{ service_root }}/factorio/bin/x64/factorio"
     save: "{{ factorio_target_save }}"


### PR DESCRIPTION
During my latest install on Ubuntu 17.10, the factorio-server.service was written without being executable, making `systemctl` skip loading it.

This tiny PR sets the mode of the service files to ensure they work with out of the box regardless of service directory defaults.