### PR TITLE
Update factorio version and fix service group.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,12 @@ More detailed information about these variables is as follows:
   Where to cache server binaries downloaded from the download_url
 
 - Variable: `server_version`<br>
-  Default: `"0.14.23"`<br>
+  Default: `"0.17.79"`<br>
   Choices:
-  - "0.15.10"
-  - "0.15.9"
-  - "0.15.6"
+  - "0.17.79"
+  - "0.17.74"
+  - "0.16.51"
+  - "0.15.40"
   - "0.14.23"
   - "0.13.20"
   - "0.12.35"
@@ -61,6 +62,14 @@ More detailed information about these variables is as follows:
   The URL to download the server binary from. This will only be downloaded if
   the path `"{{ server_sources }}/factorio-{{ server_version }}.tar.gz"` does
   not exist.
+
+- Variable: `download_checksum`<br>
+  Default: `"sha256:9ace12fa986df028dc1851bf4de2cb038044d743e98823bc1c48ba21aa4d23df"`
+  Comments:<br>
+  The checksum that must match the downloaded server binary. This ensures the integrity.
+  If you change the `download_url`, you need to adapt the checksum as well. To get the
+  checksum of a server binary, you can use `curl --silent --location <download_url> | sha256sum`.
+  To disable the checksum verification, just set it to an empty string (`""`).
 
 - Variable: `service_name`<br>
   Default: `"factorio-server"`<br>

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 server_version: "0.17.79"
 server_sources: "/opt/games/sources/factorio"
 download_url: "https://www.factorio.com/get-download/{{ server_version }}/headless/linux64"
+download_checksum: "sha256:9ace12fa986df028dc1851bf4de2cb038044d743e98823bc1c48ba21aa4d23df"
 
 # Configs for the service running the server
 service_name: "factorio-server"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # defaults file for factorio
-server_version: "0.14.23"
+server_version: "0.17.79"
 server_sources: "/opt/games/sources/factorio"
 download_url: "https://www.factorio.com/get-download/{{ server_version }}/headless/linux64"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,6 +27,7 @@
   get_url:
     url: "{{ download_url }}"
     dest: "{{ server_sources }}/factorio-{{ server_version }}.tar.gz"
+    checksum: "{{ download_checksum }}"
   when: factorio_bin.stat.exists == False
 
 # Copy the factorio version to the production location

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,16 @@
 ---
 # tasks file for factorio
 # Create the user and group to run the factorio server
+- name: "{{ ansible_name_prefix }} Create OS group for factorio"
+  group:
+    name: "{{ service_group }}"
+    state: present
+
 - name: "{{ ansible_name_prefix }} Create OS user for factorio"
   user:
     name: "{{ service_user }}"
     state: present
+    group: "{{ service_group }}"
 
 - name: "{{ ansible_name_prefix }} Create OS group for factorio"
   group:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,29 +1,29 @@
 ---
 # tasks file for factorio
 # Create the user and group to run the factorio server
-- name: "{{ansible_name_prefix }} Create OS user for factorio"
+- name: "{{ ansible_name_prefix }} Create OS user for factorio"
   user:
     name: "{{ service_user }}"
     state: present
 
-- name: "{{ansible_name_prefix }} Create OS group for factorio"
+- name: "{{ ansible_name_prefix }} Create OS group for factorio"
   group:
     name: "{{ service_group }}"
     state: present
 
 # Download the factorio server version if needed
-- name: "{{ansible_name_prefix }} Make factorio bin source folder"
+- name: "{{ ansible_name_prefix }} Make factorio bin source folder"
   file:
     path: "{{ server_sources }}"
     state: directory
     mode: u+rwx
 
-- name: "{{ansible_name_prefix }} Check factorio bin version exists"
+- name: "{{ ansible_name_prefix }} Check factorio bin version exists"
   stat:
     path: "{{ server_sources }}/factorio-{{ server_version }}.tar.gz"
   register: factorio_bin
 
-- name: "{{ansible_name_prefix }} Download factorio headless server from {{ download_url }}"
+- name: "{{ ansible_name_prefix }} Download factorio headless server from {{ download_url }}"
   get_url:
     url: "{{ download_url }}"
     dest: "{{ server_sources }}/factorio-{{ server_version }}.tar.gz"
@@ -31,7 +31,7 @@
   when: factorio_bin.stat.exists == False
 
 # Copy the factorio version to the production location
-- name: "{{ansible_name_prefix }} Make factorio bin source folder"
+- name: "{{ ansible_name_prefix }} Make factorio bin source folder"
   file:
     path: "{{ service_root }}"
     state: directory
@@ -44,7 +44,7 @@
     dest: "{{ service_root }}"
     creates: "{{ service_root }}/factorio"
 
-- name: "{{ ansible_name_prefix }} Make sure game save directory exsits"
+- name: "{{ ansible_name_prefix }} Make sure game save directory exists"
   file:
     path: "{{ service_root }}/factorio/saves"
     state: directory

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,17 +18,11 @@
     state: directory
     mode: u+rwx
 
-- name: "{{ ansible_name_prefix }} Check factorio bin version exists"
-  stat:
-    path: "{{ server_sources }}/factorio-{{ server_version }}.tar.gz"
-  register: factorio_bin
-
 - name: "{{ ansible_name_prefix }} Download factorio headless server from {{ download_url }}"
   get_url:
     url: "{{ download_url }}"
     dest: "{{ server_sources }}/factorio-{{ server_version }}.tar.gz"
     checksum: "{{ download_checksum }}"
-  when: factorio_bin.stat.exists == False
 
 # Copy the factorio version to the production location
 - name: "{{ ansible_name_prefix }} Make factorio bin source folder"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,11 +12,6 @@
     state: present
     group: "{{ service_group }}"
 
-- name: "{{ ansible_name_prefix }} Create OS group for factorio"
-  group:
-    name: "{{ service_group }}"
-    state: present
-
 # Download the factorio server version if needed
 - name: "{{ ansible_name_prefix }} Make factorio bin source folder"
   file:


### PR DESCRIPTION
Hi, your role is really great, thanks a lot!.

This PR sets Factorio version 0.17.79 as default and validates the download using checksum. 
Now the service_user have the service_group as primary group (could be different before)

Sadly I'm not able to get the tests running. There was some changes to get the deployment done. But the service can't be started, because systemd is not runable in a docker container (without a lot of work I guess). Changes regarding this are on the `fix-tests` branch.