### PR TITLE
use include_tasks instead of include

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Brahm Lower
   description: A role for creating Factorio servers
   license: license (GPLv3)
-  min_ansible_version: 2.0
+  min_ansible_version: 2.10
   platforms:
     - name: EL
       versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,16 +49,16 @@
 
 # Create the various settings files
 - name: "{{ ansible_name_prefix }} Set server settings"
-  include: set-server-settings.yml
+  include_tasks: set-server-settings.yml
 
 - name: "{{ ansible_name_prefix }} Set server whitelist"
-  include: set-server-whitelist.yml
+  include_tasks: set-server-whitelist.yml
 
 - name: "{{ ansible_name_prefix }} Set map gen settings"
-  include: set-map-gen-settings.yml
+  include_tasks: set-map-gen-settings.yml
 
 - name: "{{ ansible_name_prefix }} Set map settings"
-  include: set-map-settings.yml
+  include_tasks: set-map-settings.yml
 
 # Create the save if one doesn't already exist
 - name: "{{ ansible_name_prefix }} Create default save file"


### PR DESCRIPTION
Since release 2023-05-16 include is no longer supported, instead include_tasks or import_tasks should be used. This now works with the current ansible_core release.